### PR TITLE
Send agent port to Zabbix Server when doing active checks.

### DIFF
--- a/zorka-core/src/main/java/com/jitlogic/zorka/core/integ/zabbix/ZabbixActiveAgent.java
+++ b/zorka-core/src/main/java/com/jitlogic/zorka/core/integ/zabbix/ZabbixActiveAgent.java
@@ -62,6 +62,7 @@ public class ZabbixActiveAgent implements Runnable, ZorkaService {
 
     /** Hostname agent advertises itself to zabbix. */
 	private String agentHost;
+	private int agentPort;
 	private String activeIpPort;
 
     /** Interval between fetching new item list from Zabbix. */
@@ -119,6 +120,8 @@ public class ZabbixActiveAgent implements Runnable, ZorkaService {
 
 	protected void setup() {
 		log.debug(ZorkaLogger.ZAG_DEBUG, "ZabbixActive setup...");
+
+		agentPort = config.intCfg("zabbix.listen.port", 10055);
 
 		/* Zabbix Server IP:Port */
 		activeIpPort = config.stringCfg(prefix + ".server.addr", defaultAddr);
@@ -271,7 +274,7 @@ public class ZabbixActiveAgent implements Runnable, ZorkaService {
 				ZabbixActiveRequest request = new ZabbixActiveRequest(socket);
 
 				// send Active Check Message 
-				request.sendActiveMessage(agentHost, config.stringCfg(prefix + ".host_metadata", ""));
+				request.sendActiveMessage(agentHost, agentPort, config.stringCfg(prefix + ".host_metadata", ""));
 
 				// get requests for metrics
 				ActiveCheckResponse response = request.getActiveResponse();

--- a/zorka-core/src/main/java/com/jitlogic/zorka/core/integ/zabbix/ZabbixActiveRequest.java
+++ b/zorka-core/src/main/java/com/jitlogic/zorka/core/integ/zabbix/ZabbixActiveRequest.java
@@ -112,8 +112,8 @@ public class ZabbixActiveRequest {
 	 * @param host destination host
 	 * @throws IOException if I/O error occurs
 	 */
-	public void sendActiveMessage(String host, String hostMetadata) throws IOException {
-		String message = ZabbixUtils.createActiveCheck(host, hostMetadata);
+	public void sendActiveMessage(String host, int port, String hostMetadata) throws IOException {
+		String message = ZabbixUtils.createActiveCheck(host, port, hostMetadata);
 		send(message);
 	} // send()
 

--- a/zorka-core/src/main/java/com/jitlogic/zorka/core/integ/zabbix/ZabbixUtils.java
+++ b/zorka-core/src/main/java/com/jitlogic/zorka/core/integ/zabbix/ZabbixUtils.java
@@ -56,9 +56,10 @@ public final class ZabbixUtils {
 	/**
 	 * Active Check constants
 	 */
-	private static String _ACTIVECHECK_MSG = "{ \"request\":\"active checks\", \"host\":\"<hostname>\", \"host_metadata\": \"<host_metadata>\"}";
+	private static String _ACTIVECHECK_MSG = "{ \"request\":\"active checks\", \"host\":\"<hostname>\", \"host_metadata\": \"<host_metadata>\", \"port\":<port>}";
 
 	private static String _HOSTNAME_TAG = "<hostname>";
+	private static String _PORT_TAG = "<port>";
 	private static String _HOSTMETADATA_TAG = "<host_metadata>";
 
 
@@ -108,8 +109,9 @@ public final class ZabbixUtils {
 	 * @param host
 	 * @return
 	 */
-	public static String createActiveCheck(String host, String hostMetadata) {
-		String res = _ACTIVECHECK_MSG.replace(_HOSTNAME_TAG, host);
+	public static String createActiveCheck(String host, int port, String hostMetadata) {
+		String res = _ACTIVECHECK_MSG.replace(_HOSTNAME_TAG, host)
+			.replace(_PORT_TAG, String.valueOf(port));
 		return res.replace(_HOSTMETADATA_TAG, hostMetadata);
 	}
 


### PR DESCRIPTION
This should set up the agent correctly in Zabbix Server when auto registration actions are performed based on agent's active check requests.