### PR TITLE
Avoid increased native memory overhead in HotSpot

### DIFF
--- a/zorka-core/src/main/java/com/jitlogic/zorka/core/spy/SpyClassVisitor.java
+++ b/zorka-core/src/main/java/com/jitlogic/zorka/core/spy/SpyClassVisitor.java
@@ -76,6 +76,8 @@ public class SpyClassVisitor extends ClassVisitor {
 
     private boolean recursive;
 
+    private boolean bytecodeWasModified = false;
+
     /**
      * Creates Spy class visitor.
      *
@@ -191,6 +193,7 @@ public class SpyClassVisitor extends ClassVisitor {
         }
 
         if (ctxs.size() > 0 || doTrace) {
+            bytecodeWasModified = true;
             return new SpyMethodVisitor(m, doTrace ? symbolRegistry : null, className,
                     classAnnotations, classInterfaces, access, methodName, methodDesc, ctxs, mv);
         }
@@ -210,5 +213,9 @@ public class SpyClassVisitor extends ClassVisitor {
      */
     protected MethodVisitor createVisitor(int access, String name, String desc, String signature, String[] exceptions) {
         return cv.visitMethod(access, name, desc, signature, exceptions);
+    }
+
+    public boolean wasBytecodeModified() {
+        return bytecodeWasModified;
     }
 }

--- a/zorka-core/src/test/java/com/jitlogic/zorka/core/test/spy/BytecodeInstrumentationUnitTest.java
+++ b/zorka-core/src/test/java/com/jitlogic/zorka/core/test/spy/BytecodeInstrumentationUnitTest.java
@@ -39,6 +39,13 @@ public class BytecodeInstrumentationUnitTest extends BytecodeInstrumentationFixt
         assertEquals("should be of class " + TCLASS1, TCLASS1, obj.getClass().getName());
     }
 
+    @Test
+    public void testNoTransformation() throws Exception {
+        TransformationResult transformationResult = transform(engine, TCLASS1);
+
+        assertNull("should not transform classes not touched by instrumentation", transformationResult.transformedBytecode);
+    }
+
 
     @Test
     public void testTrivialInstrumentOnlyEntryPointWithThisRef() throws Exception {

--- a/zorka-core/src/test/java/com/jitlogic/zorka/core/test/spy/support/TestSpyTransformer.java
+++ b/zorka-core/src/test/java/com/jitlogic/zorka/core/test/spy/support/TestSpyTransformer.java
@@ -42,7 +42,7 @@ public class TestSpyTransformer extends SpyClassTransformer {
     }
 
     @Override
-    protected ClassVisitor createVisitor(ClassLoader classLoader, String className, List<SpyDefinition> found, Tracer tracer, ClassWriter cw) {
+    protected SpyClassVisitor createVisitor(ClassLoader classLoader, String className, List<SpyDefinition> found, Tracer tracer, ClassWriter cw) {
 
         if (debug) {
             return new SpyClassVisitor(this, classLoader, sreg, className, found,


### PR DESCRIPTION
From the javadoc of `java.lang.instrument.ClassFileTransformer`:

```java
    /**
     * ...
     *
     * @return  a well-formed class file buffer (the result of the transform),
                or <code>null</code> if no transform is performed.
     */
    byte[]
    transform(  ClassLoader         loader,
                String              className,
                Class<?>            classBeingRedefined,
                ProtectionDomain    protectionDomain,
                byte[]              classfileBuffer)
        throws IllegalClassFormatException;
```

Whenever a transformer returns non-`null` value from this method, HotSpot assumes that the class was modified, and if `canRetransform` is `true` caches the original bytecode in native memory (see [`jvmtiExport.cpp`](http://hg.openjdk.java.net/jdk9/jdk9/hotspot/file/7e7e50ac4faf/src/share/vm/prims/jvmtiExport.cpp#l618)).

Currently `null` is never returned, so every single loaded class gets cached.